### PR TITLE
7 datawithbump never used in example

### DIFF
--- a/programs/0-signer-authorization/insecure/src/lib.rs
+++ b/programs/0-signer-authorization/insecure/src/lib.rs
@@ -1,20 +1,11 @@
 use anchor_lang::prelude::*;
 
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
-/// Objective: Authenticating Signer of transaction
-///
-/// Topics: [AccountInfo](https://docs.rs/anchor-lang/0.24.2/anchor_lang/prelude/struct.AccountInfo.html), [Signer](https://docs.rs/anchor-lang/0.24.2/anchor_lang/accounts/signer/struct.Signer.html)
-///
-/// The following program example accepts
-/// arbitrary solana account hence not safe.
-/// and log_message method is also not performing any
-/// safety check
 #[program]
 pub mod signer_authorization_insecure {
     use super::*;
 
     pub fn log_message(ctx: Context<LogMessage>) -> ProgramResult {
-        // no account checks performed here
         msg!("GM {}", ctx.accounts.authority.key().to_string());
         Ok(())
     }
@@ -22,7 +13,5 @@ pub mod signer_authorization_insecure {
 
 #[derive(Accounts)]
 pub struct LogMessage<'info> {
-    /// arbitrary solana account\
-    /// read more about [AccountInfo](https://docs.rs/anchor-lang/0.24.2/anchor_lang/prelude/struct.AccountInfo.html)
     authority: AccountInfo<'info>,
 }

--- a/programs/0-signer-authorization/insecure/src/lib.rs
+++ b/programs/0-signer-authorization/insecure/src/lib.rs
@@ -1,12 +1,20 @@
 use anchor_lang::prelude::*;
 
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
-
+/// Objective: Authenticating Signer of transaction
+///
+/// Topics: [AccountInfo](https://docs.rs/anchor-lang/0.24.2/anchor_lang/prelude/struct.AccountInfo.html), [Signer](https://docs.rs/anchor-lang/0.24.2/anchor_lang/accounts/signer/struct.Signer.html)
+///
+/// The following program example accepts
+/// arbitrary solana account hence not safe.
+/// and log_message method is also not performing any
+/// safety check
 #[program]
 pub mod signer_authorization_insecure {
     use super::*;
 
     pub fn log_message(ctx: Context<LogMessage>) -> ProgramResult {
+        // no account checks performed here
         msg!("GM {}", ctx.accounts.authority.key().to_string());
         Ok(())
     }
@@ -14,5 +22,7 @@ pub mod signer_authorization_insecure {
 
 #[derive(Accounts)]
 pub struct LogMessage<'info> {
+    /// arbitrary solana account\
+    /// read more about [AccountInfo](https://docs.rs/anchor-lang/0.24.2/anchor_lang/prelude/struct.AccountInfo.html)
     authority: AccountInfo<'info>,
 }

--- a/programs/0-signer-authorization/recommended/src/lib.rs
+++ b/programs/0-signer-authorization/recommended/src/lib.rs
@@ -2,11 +2,16 @@ use anchor_lang::prelude::*;
 
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
+/// Utilizes anchor's Signer to authenticate
+/// the transaction signer
+///
+/// [Signer](https://docs.rs/anchor-lang/0.24.2/anchor_lang/accounts/signer/struct.Signer.html)
 #[program]
 pub mod signer_authorization_recommended {
     use super::*;
 
     pub fn log_message(ctx: Context<LogMessage>) -> ProgramResult {
+        // Signer verifies authenticity no need of explicit checks here
         msg!("GM {}", ctx.accounts.authority.key().to_string());
         Ok(())
     }
@@ -14,5 +19,6 @@ pub mod signer_authorization_recommended {
 
 #[derive(Accounts)]
 pub struct LogMessage<'info> {
+    /// signer performs Signer.info.is_signer == true check
     authority: Signer<'info>,
 }

--- a/programs/0-signer-authorization/recommended/src/lib.rs
+++ b/programs/0-signer-authorization/recommended/src/lib.rs
@@ -2,16 +2,11 @@ use anchor_lang::prelude::*;
 
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
-/// Utilizes anchor's Signer to authenticate
-/// the transaction signer
-///
-/// [Signer](https://docs.rs/anchor-lang/0.24.2/anchor_lang/accounts/signer/struct.Signer.html)
 #[program]
 pub mod signer_authorization_recommended {
     use super::*;
 
     pub fn log_message(ctx: Context<LogMessage>) -> ProgramResult {
-        // Signer verifies authenticity no need of explicit checks here
         msg!("GM {}", ctx.accounts.authority.key().to_string());
         Ok(())
     }
@@ -19,6 +14,5 @@ pub mod signer_authorization_recommended {
 
 #[derive(Accounts)]
 pub struct LogMessage<'info> {
-    /// signer performs Signer.info.is_signer == true check
     authority: Signer<'info>,
 }

--- a/programs/7-bump-seed-canonicalization/secure/src/lib.rs
+++ b/programs/7-bump-seed-canonicalization/secure/src/lib.rs
@@ -13,7 +13,7 @@ pub mod bump_seed_canonicalization_secure {
         bump: u8,
     ) -> ProgramResult {
         let (address, expected_bump) =
-            Pubkey::find_program_address(&[key.to_le_bytes().as_ref(), &[bump]], ctx.program_id);
+            Pubkey::find_program_address(&[key.to_le_bytes().as_ref()], ctx.program_id);
 
         if address != ctx.accounts.data.key() {
             return Err(ProgramError::InvalidArgument);
@@ -35,10 +35,4 @@ pub struct BumpSeed<'info> {
 #[account]
 pub struct Data {
     value: u64,
-}
-
-#[account]
-pub struct DataWithBump {
-    value: u64,
-    bump: u8,
 }


### PR DESCRIPTION
removed unused account 

Also removed bump passed as seed while getting program address. Which was produced while getting the PDA on client side. 

So technically what we are expecting to happen

```
let (address, expected_bump) = 
    Pubkey::find_program_address(&[key.to_le_bytes().as_ref()], ctx.program_id);
```
and
```
 let (address, expected_bump) = 
    Pubkey::find_program_address(&[key.to_le_bytes().as_ref(), &[bump_from_client_side]], ctx.program_id);
```

the bump returned by both should be the same. Which would not be the case.

