### PR TITLE
Update user authority from context accounts in class 3

### DIFF
--- a/programs/4-initialization/recommended/src/lib.rs
+++ b/programs/4-initialization/recommended/src/lib.rs
@@ -7,6 +7,8 @@ pub mod reinitialization_4 {
     use super::*;
 
     pub fn init(_ctx: Context<Init>) -> ProgramResult {
+        let user = &mut ctx.accounts.user;
+        user.authority = *ctx.accounts.authority.key;
         msg!("GM");
         Ok(())
     }


### PR DESCRIPTION
The current recommended code does not seem to match the behavior of both the insecure and secure versions.