### PR TITLE
Add comments to identify insecure, recommended, and secure patterns in 0-signer-authorization

### DIFF
--- a/programs/0-signer-authorization/insecure/src/lib.rs
+++ b/programs/0-signer-authorization/insecure/src/lib.rs
@@ -1,6 +1,8 @@
 use anchor_lang::prelude::*;
 
+// Insecure: `authority` is of type `AccountInfo` without any checks to ensure it's a signer.
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
 #[program]
 pub mod signer_authorization_insecure {
     use super::*;
@@ -13,5 +15,5 @@ pub mod signer_authorization_insecure {
 
 #[derive(Accounts)]
 pub struct LogMessage<'info> {
-    authority: AccountInfo<'info>,
+    authority: AccountInfo<'info>,  // No check for signer authority.
 }

--- a/programs/0-signer-authorization/recommended/src/lib.rs
+++ b/programs/0-signer-authorization/recommended/src/lib.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 
+// Recommended: Changing `authority` to type `Signer` ensures the account has signer privileges.
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 #[program]
@@ -14,5 +15,5 @@ pub mod signer_authorization_recommended {
 
 #[derive(Accounts)]
 pub struct LogMessage<'info> {
-    authority: Signer<'info>,
+    authority: Signer<'info>,  // Ensures that `authority` is a valid signer.
 }

--- a/programs/0-signer-authorization/secure/src/lib.rs
+++ b/programs/0-signer-authorization/secure/src/lib.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 
+// Secure: Explicitly checks if `authority` is a signer before proceeding.
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 #[program]
@@ -8,7 +9,7 @@ pub mod signer_authorization_secure {
 
     pub fn log_message(ctx: Context<LogMessage>) -> ProgramResult {
         if !ctx.accounts.authority.is_signer {
-            return Err(ProgramError::MissingRequiredSignature);
+            return Err(ProgramError::MissingRequiredSignature);  // Secure: Throws an error if `authority` is not a signer.
         }
         msg!("GM {}", ctx.accounts.authority.key().to_string());
         Ok(())
@@ -17,5 +18,5 @@ pub mod signer_authorization_secure {
 
 #[derive(Accounts)]
 pub struct LogMessage<'info> {
-    authority: AccountInfo<'info>,
+    authority: AccountInfo<'info>,  // Type `AccountInfo` allows additional checks.
 }


### PR DESCRIPTION
This pull request adds comments to the 0-signer-authorization program in the Sealevel Attacks repository. The comments clarify which parts of the code are insecure, recommended, and secure. These changes aim to improve the educational value of the examples by clearly distinguishing the different levels of security practices in the code.