### PR TITLE
Add comments to account_data_matching programs

### DIFF
--- a/programs/1-account-data-matching/insecure/src/lib.rs
+++ b/programs/1-account-data-matching/insecure/src/lib.rs
@@ -9,7 +9,9 @@ pub mod account_data_matching_insecure {
     use super::*;
 
     pub fn log_message(ctx: Context<LogMessage>) -> ProgramResult {
+        // Directly unpacking token account data without validating ownership
         let token = SplTokenAccount::unpack(&ctx.accounts.token.data.borrow())?;
+        // Logging the account balance
         msg!("Your account balance is: {}", token.amount);
         Ok(())
     }
@@ -17,6 +19,8 @@ pub mod account_data_matching_insecure {
 
 #[derive(Accounts)]
 pub struct LogMessage<'info> {
+    // This account is assumed to be a valid token account without verification
     token: AccountInfo<'info>,
+    // This signer is not validated against the token account owner
     authority: Signer<'info>,
 }

--- a/programs/1-account-data-matching/recommended/src/lib.rs
+++ b/programs/1-account-data-matching/recommended/src/lib.rs
@@ -8,6 +8,7 @@ pub mod account_data_matching_recommended {
     use super::*;
 
     pub fn log_message(ctx: Context<LogMessage>) -> ProgramResult {
+        // Logging the account balance directly from the validated token account
         msg!("Your account balance is: {}", ctx.accounts.token.amount);
         Ok(())
     }
@@ -15,7 +16,9 @@ pub mod account_data_matching_recommended {
 
 #[derive(Accounts)]
 pub struct LogMessage<'info> {
+    // Validating that the authority is the owner of the token account
     #[account(constraint = authority.key == &token.owner)]
     token: Account<'info, TokenAccount>,
+    // Authority must sign the transaction and own the token account
     authority: Signer<'info>,
 }

--- a/programs/1-account-data-matching/secure/src/lib.rs
+++ b/programs/1-account-data-matching/secure/src/lib.rs
@@ -9,17 +9,22 @@ pub mod account_data_matching_secure {
     use super::*;
 
     pub fn log_message(ctx: Context<LogMessage>) -> ProgramResult {
+        // Unpacking token account data
         let token = SplTokenAccount::unpack(&ctx.accounts.token.data.borrow())?;
+        // Explicitly checking that the authority is the owner of the token account
         if ctx.accounts.authority.key != &token.owner {
             return Err(ProgramError::InvalidAccountData);
         }
-        msg!("Your acocunt balance is: {}", token.amount);
+        // Logging the account balance if ownership is verified
+        msg!("Your account balance is: {}", token.amount);
         Ok(())
     }
 }
 
 #[derive(Accounts)]
 pub struct LogMessage<'info> {
+    // Token account data needs to be carefully handled and ownership verified
     token: AccountInfo<'info>,
+    // This signer is required to be the owner of the token account
     authority: Signer<'info>,
 }


### PR DESCRIPTION
Added comments to the 1-account-data-matching programs (insecure, recommended, and secure versions). These comments clarify key parts of the code, such as ownership verification and potential security concerns.