### PR TITLE
Added comments to insecure, recommended, and secure owner-check programs

### DIFF
--- a/programs/2-owner-checks/insecure/src/lib.rs
+++ b/programs/2-owner-checks/insecure/src/lib.rs
@@ -10,10 +10,15 @@ pub mod owner_checks_insecure {
     use super::*;
 
     pub fn log_message(ctx: Context<LogMessage>) -> ProgramResult {
+        // Unpack the token account data from the AccountInfo
         let token = SplTokenAccount::unpack(&ctx.accounts.token.data.borrow())?;
+        
+        // Check if the authority matches the token owner
         if ctx.accounts.authority.key != &token.owner {
             return Err(ProgramError::InvalidAccountData);
         }
+        
+        // Log the token amount
         msg!("Your account balance is: {}", token.amount);
         Ok(())
     }
@@ -21,6 +26,8 @@ pub mod owner_checks_insecure {
 
 #[derive(Accounts)]
 pub struct LogMessage<'info> {
+    // Token account information
     token: AccountInfo<'info>,
+    // Authority that must sign the transaction
     authority: Signer<'info>,
 }

--- a/programs/2-owner-checks/recommended/src/lib.rs
+++ b/programs/2-owner-checks/recommended/src/lib.rs
@@ -8,6 +8,7 @@ pub mod owner_checks_recommended {
     use super::*;
 
     pub fn log_message(ctx: Context<LogMessage>) -> ProgramResult {
+        // Log the token amount directly from the TokenAccount
         msg!("Your account balance is: {}", ctx.accounts.token.amount);
         Ok(())
     }
@@ -15,7 +16,9 @@ pub mod owner_checks_recommended {
 
 #[derive(Accounts)]
 pub struct LogMessage<'info> {
+    // Token account information with a constraint to ensure the authority is the owner
     #[account(constraint = authority.key == &token.owner)]
     token: Account<'info, TokenAccount>,
+    // Authority that must sign the transaction
     authority: Signer<'info>,
 }

--- a/programs/2-owner-checks/secure/src/lib.rs
+++ b/programs/2-owner-checks/secure/src/lib.rs
@@ -10,13 +10,20 @@ pub mod owner_checks_secure {
     use super::*;
 
     pub fn log_message(ctx: Context<LogMessage>) -> ProgramResult {
+        // Unpack the token account data from the AccountInfo
         let token = SplTokenAccount::unpack(&ctx.accounts.token.data.borrow())?;
+        
+        // Ensure the token account is actually an SPL Token account
         if ctx.accounts.token.owner != &spl_token::ID {
             return Err(ProgramError::InvalidAccountData);
         }
+        
+        // Check if the authority matches the token owner
         if ctx.accounts.authority.key != &token.owner {
             return Err(ProgramError::InvalidAccountData);
         }
+        
+        // Log the token amount
         msg!("Your account balance is: {}", token.amount);
         Ok(())
     }
@@ -24,6 +31,8 @@ pub mod owner_checks_secure {
 
 #[derive(Accounts)]
 pub struct LogMessage<'info> {
+    // Token account information
     token: AccountInfo<'info>,
+    // Authority that must sign the transaction
     authority: Signer<'info>,
 }


### PR DESCRIPTION
Added comments to the insecure, recommended, and secure versions of the owner-check program.
Comments were added to explain key parts of the code, including token account unpacking, authority checks, and constraints for security.