### PR TITLE
Add comments to insecure, recommended, and secure examples

### DIFF
--- a/programs/3-type-cosplay/insecure/src/lib.rs
+++ b/programs/3-type-cosplay/insecure/src/lib.rs
@@ -1,6 +1,7 @@
 use anchor_lang::prelude::*;
 use borsh::{BorshDeserialize, BorshSerialize};
 
+// Declare the program ID
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 #[program]
@@ -8,13 +9,20 @@ pub mod type_cosplay_insecure {
     use super::*;
 
     pub fn update_user(ctx: Context<UpdateUser>) -> ProgramResult {
+        // Attempt to deserialize the user account data
         let user = User::try_from_slice(&ctx.accounts.user.data.borrow()).unwrap();
+
+        // Check if the owner of the account is the program itself
         if ctx.accounts.user.owner != ctx.program_id {
             return Err(ProgramError::IllegalOwner);
         }
+
+        // Check if the authority matches the one stored in the user account
         if user.authority != ctx.accounts.authority.key() {
             return Err(ProgramError::InvalidAccountData);
         }
+
+        // Log a message for debugging purposes
         msg!("GM {}", user.authority);
         Ok(())
     }
@@ -22,16 +30,16 @@ pub mod type_cosplay_insecure {
 
 #[derive(Accounts)]
 pub struct UpdateUser<'info> {
-    user: AccountInfo<'info>,
-    authority: Signer<'info>,
+    user: AccountInfo<'info>, // User account (AccountInfo used instead of Account<User>)
+    authority: Signer<'info>, // The signer who is expected to be the authority
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct User {
-    authority: Pubkey,
+    authority: Pubkey, // Public key of the authority who can update the user
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct Metadata {
-    account: Pubkey,
+    account: Pubkey, // Metadata account holding a public key
 }

--- a/programs/3-type-cosplay/recommended/src/lib.rs
+++ b/programs/3-type-cosplay/recommended/src/lib.rs
@@ -1,6 +1,7 @@
 use anchor_lang::prelude::*;
 use borsh::{BorshDeserialize, BorshSerialize};
 
+// Declare the program ID
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 #[program]
@@ -8,6 +9,7 @@ pub mod type_cosplay_recommended {
     use super::*;
 
     pub fn update_user(ctx: Context<UpdateUser>) -> ProgramResult {
+        // Log a message for debugging purposes
         msg!("GM {}", ctx.accounts.user.authority);
         Ok(())
     }
@@ -15,17 +17,17 @@ pub mod type_cosplay_recommended {
 
 #[derive(Accounts)]
 pub struct UpdateUser<'info> {
-    #[account(has_one = authority)]
-    user: Account<'info, User>,
-    authority: Signer<'info>,
+    #[account(has_one = authority)] // Ensures that the user account's authority matches the provided signer
+    user: Account<'info, User>,     // User account with a strict type check
+    authority: Signer<'info>,       // The signer who is expected to be the authority
 }
 
 #[account]
 pub struct User {
-    authority: Pubkey,
+    authority: Pubkey, // Public key of the authority who can update the user
 }
 
 #[account]
 pub struct Metadata {
-    account: Pubkey,
+    account: Pubkey, // Metadata account holding a public key
 }

--- a/programs/3-type-cosplay/secure/src/lib.rs
+++ b/programs/3-type-cosplay/secure/src/lib.rs
@@ -1,6 +1,7 @@
 use anchor_lang::prelude::*;
 use borsh::{BorshDeserialize, BorshSerialize};
 
+// Declare the program ID
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 #[program]
@@ -8,16 +9,25 @@ pub mod type_cosplay_secure {
     use super::*;
 
     pub fn update_user(ctx: Context<UpdateUser>) -> ProgramResult {
+        // Attempt to deserialize the user account data
         let user = User::try_from_slice(&ctx.accounts.user.data.borrow()).unwrap();
+
+        // Check if the owner of the account is the program itself
         if ctx.accounts.user.owner != ctx.program_id {
             return Err(ProgramError::IllegalOwner);
         }
+
+        // Check if the authority matches the one stored in the user account
         if user.authority != ctx.accounts.authority.key() {
             return Err(ProgramError::InvalidAccountData);
         }
+
+        // Check if the account has the correct discriminant to prevent type confusion
         if user.discriminant != AccountDiscriminant::User {
             return Err(ProgramError::InvalidAccountData);
         }
+
+        // Log a message for debugging purposes
         msg!("GM {}", user.authority);
         Ok(())
     }
@@ -25,24 +35,24 @@ pub mod type_cosplay_secure {
 
 #[derive(Accounts)]
 pub struct UpdateUser<'info> {
-    user: AccountInfo<'info>,
-    authority: Signer<'info>,
+    user: AccountInfo<'info>, // User account (AccountInfo used instead of Account<User>)
+    authority: Signer<'info>, // The signer who is expected to be the authority
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct User {
-    discriminant: AccountDiscriminant,
-    authority: Pubkey,
+    discriminant: AccountDiscriminant, // Discriminant to distinguish between different account types
+    authority: Pubkey,                 // Public key of the authority who can update the user
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct Metadata {
-    discriminant: AccountDiscriminant,
-    account: Pubkey,
+    discriminant: AccountDiscriminant, // Discriminant to distinguish between different account types
+    account: Pubkey,                   // Metadata account holding a public key
 }
 
 #[derive(BorshSerialize, BorshDeserialize, PartialEq)]
 pub enum AccountDiscriminant {
-    User,
-    Metadata,
+    User,      // Discriminant value for User accounts
+    Metadata,  // Discriminant value for Metadata accounts
 }


### PR DESCRIPTION
Added necessary comments to the insecure, recommended, and secure examples in the 3-type-cosplay program. These comments help clarify the purpose of certain code segments, such as ownership checks, authority validations, and the usage of account discriminants to prevent type confusion attacks.