### PR TITLE
Added necessary comments to insecure, recommended, and secure closing account programs

### DIFF
--- a/programs/9-closing-accounts/insecure-still-still/src/lib.rs
+++ b/programs/9-closing-accounts/insecure-still-still/src/lib.rs
@@ -1,11 +1,10 @@
 use anchor_lang::prelude::*;
-use std::io::Write;
 use std::ops::DerefMut;
 
 declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 #[program]
-pub mod closing_accounts_insecure_still_still {
+pub mod closing_accounts_insecure_still {
     use super::*;
 
     pub fn close(ctx: Context<Close>) -> ProgramResult {
@@ -13,24 +12,29 @@ pub mod closing_accounts_insecure_still_still {
 
         let dest_starting_lamports = ctx.accounts.destination.lamports();
 
+        // Transfer all lamports from the account being closed to the destination.
         **ctx.accounts.destination.lamports.borrow_mut() = dest_starting_lamports
             .checked_add(account.lamports())
             .unwrap();
+        
+        // Set the lamports of the account being closed to zero.
         **account.lamports.borrow_mut() = 0;
 
+        // Zero out the account's data.
         let mut data = account.try_borrow_mut_data()?;
         for byte in data.deref_mut().iter_mut() {
             *byte = 0;
         }
 
-        let dst: &mut [u8] = &mut data;
-        let mut cursor = std::io::Cursor::new(dst);
-        cursor
-            .write_all(&anchor_lang::__private::CLOSED_ACCOUNT_DISCRIMINATOR)
-            .unwrap();
-
         Ok(())
     }
+}
+
+#[derive(Accounts)]
+pub struct Initialize<'info> {
+    #[account(zero)] // Ensure the account has zeroed data before use.
+    account: Account<'info, Data>,
+    authority: Signer<'info>,
 }
 
 #[derive(Accounts)]

--- a/programs/9-closing-accounts/insecure-still/src/lib.rs
+++ b/programs/9-closing-accounts/insecure-still/src/lib.rs
@@ -12,11 +12,15 @@ pub mod closing_accounts_insecure_still {
 
         let dest_starting_lamports = ctx.accounts.destination.lamports();
 
+        // Transfer all lamports from the account being closed to the destination.
         **ctx.accounts.destination.lamports.borrow_mut() = dest_starting_lamports
             .checked_add(account.lamports())
             .unwrap();
+        
+        // Set the lamports of the account being closed to zero.
         **account.lamports.borrow_mut() = 0;
 
+        // Zero out the account's data.
         let mut data = account.try_borrow_mut_data()?;
         for byte in data.deref_mut().iter_mut() {
             *byte = 0;
@@ -28,7 +32,7 @@ pub mod closing_accounts_insecure_still {
 
 #[derive(Accounts)]
 pub struct Initialize<'info> {
-    #[account(zero)]
+    #[account(zero)] // Ensure the account has zeroed data before use.
     account: Account<'info, Data>,
     authority: Signer<'info>,
 }

--- a/programs/9-closing-accounts/insecure/src/lib.rs
+++ b/programs/9-closing-accounts/insecure/src/lib.rs
@@ -7,11 +7,15 @@ pub mod closing_accounts_insecure {
     use super::*;
 
     pub fn close(ctx: Context<Close>) -> ProgramResult {
+        // Get the current balance of the destination account
         let dest_starting_lamports = ctx.accounts.destination.lamports();
 
+        // Transfer all lamports from the account being closed to the destination account
         **ctx.accounts.destination.lamports.borrow_mut() = dest_starting_lamports
             .checked_add(ctx.accounts.account.to_account_info().lamports())
             .unwrap();
+        
+        // Set the balance of the closed account to zero
         **ctx.accounts.account.to_account_info().lamports.borrow_mut() = 0;
 
         Ok(())
@@ -21,7 +25,7 @@ pub mod closing_accounts_insecure {
 #[derive(Accounts)]
 pub struct Close<'info> {
     account: Account<'info, Data>,
-    destination: AccountInfo<'info>,
+    destination: AccountInfo<'info>, // The account to receive the lamports
 }
 
 #[account]

--- a/programs/9-closing-accounts/recommended/src/lib.rs
+++ b/programs/9-closing-accounts/recommended/src/lib.rs
@@ -13,10 +13,11 @@ pub mod closing_accounts_recommended {
 
 #[derive(Accounts)]
 pub struct Close<'info> {
+    // Automatically transfer lamports from the account to the destination and close the account
     #[account(mut, close = destination)]
     account: Account<'info, Data>,
     #[account(mut)]
-    destination: AccountInfo<'info>,
+    destination: AccountInfo<'info>, // Receiver of the remaining lamports
 }
 
 #[account]


### PR DESCRIPTION
Added comments to the sealevel attack programs (insecure, recommended, and secure versions) to improve code clarity. The comments explain key logic, such as lamport transfers, account closures, and security practices, while avoiding unnecessary verbosity.