### PR TITLE
Add comments to sealevel attacks examples: insecure, recommended, and secure

### DIFF
--- a/programs/10-sysvar-address-checking/insecure/src/lib.rs
+++ b/programs/10-sysvar-address-checking/insecure/src/lib.rs
@@ -7,6 +7,8 @@ pub mod insecure {
     use super::*;
 
     pub fn check_sysvar_address(ctx: Context<CheckSysvarAddress>) -> Result<()> {
+        // Simply logs the rent account's public key.
+        // No validation is performed, which can lead to attacks.
         msg!("Rent Key -> {}", ctx.accounts.rent.key().to_string());
         Ok(())
     }
@@ -14,5 +16,6 @@ pub mod insecure {
 
 #[derive(Accounts)]
 pub struct CheckSysvarAddress<'info> {
+    // Rent account is defined as an AccountInfo, allowing any account to be passed, leading to potential exploitation.
     rent: AccountInfo<'info>,
 }

--- a/programs/10-sysvar-address-checking/recommended/src/lib.rs
+++ b/programs/10-sysvar-address-checking/recommended/src/lib.rs
@@ -7,6 +7,8 @@ pub mod recommended {
     use super::*;
 
     pub fn check_sysvar_address(ctx: Context<CheckSysvarAddress>) -> Result<()> {
+        // Logs the rent account's public key.
+        // Here the rent account is properly typed as a Sysvar, ensuring it's a valid system account.
         msg!("Rent Key -> {}", ctx.accounts.rent.key().to_string());
         Ok(())
     }
@@ -14,5 +16,6 @@ pub mod recommended {
 
 #[derive(Accounts)]
 pub struct CheckSysvarAddress<'info> {
+    // Rent account is correctly specified as the Sysvar Rent, providing built-in validation.
     rent: Sysvar<'info, Rent>,
 }

--- a/programs/10-sysvar-address-checking/secure/src/lib.rs
+++ b/programs/10-sysvar-address-checking/secure/src/lib.rs
@@ -7,6 +7,7 @@ pub mod secure {
     use super::*;
 
     pub fn check_sysvar_address(ctx: Context<CheckSysvarAddress>) -> Result<()> {
+        // Validates that the passed rent account is actually the Sysvar Rent account by comparing its key to the system's Rent ID.
         require_eq!(ctx.accounts.rent.key(), sysvar::rent::ID);
         msg!("Rent Key -> {}", ctx.accounts.rent.key().to_string());
         Ok(())
@@ -15,5 +16,6 @@ pub mod secure {
 
 #[derive(Accounts)]
 pub struct CheckSysvarAddress<'info> {
+    // Rent account is again an AccountInfo, but manual validation is enforced to check if it matches the Sysvar Rent account.
     rent: AccountInfo<'info>,
 }


### PR DESCRIPTION
Added comments to the insecure, recommended, and secure versions of the `check_sysvar_address` programs. These comments clarify the risks and improvements associated with each approach, highlighting key aspects such as account validation and the potential for exploitation in the insecure example.
